### PR TITLE
Fix display of next sync time in sync settings

### DIFF
--- a/src/modules/android/android-app/shared/android-app-helper/android-app-helper.service.ts
+++ b/src/modules/android/android-app/shared/android-app-helper/android-app-helper.service.ts
@@ -137,8 +137,8 @@ export default class AndroidAppHelperService extends AppHelperService {
     return pages;
   }
 
-  getNextScheduledSyncUpdateCheck(): ng.IPromise<string> {
-    return this.$q.resolve('');
+  getNextScheduledSyncUpdateCheck(): ng.IPromise<Date> {
+    return this.$q.resolve(new Date(''));
   }
 
   getSyncQueueLength(): ng.IPromise<number> {

--- a/src/modules/app/app-settings/sync-settings/sync-settings.component.ts
+++ b/src/modules/app/app-settings/sync-settings/sync-settings.component.ts
@@ -102,7 +102,7 @@ export default class SyncSettingsComponent implements OnInit {
       .then((results) => {
         if (results[0]) {
           this.updatesAvailable = true;
-          const nextUpdateDate = new Date(results[1]);
+          const nextUpdateDate = results[1];
           this.nextUpdate = this.platformSvc
             .getI18nString(this.Strings.View.Settings.Sync.UpdatesAvailable.True)
             .replace('{date}', nextUpdateDate.toLocaleTimeString());

--- a/src/modules/app/shared/app-helper/app-helper.service.ts
+++ b/src/modules/app/shared/app-helper/app-helper.service.ts
@@ -160,7 +160,7 @@ export default abstract class AppHelperService {
       });
   }
 
-  abstract getNextScheduledSyncUpdateCheck(): ng.IPromise<string>;
+  abstract getNextScheduledSyncUpdateCheck(): ng.IPromise<Date>;
 
   abstract getSyncQueueLength(): ng.IPromise<number>;
 

--- a/src/modules/webext/webext-app/shared/webext-app-helper/webext-app-helper.service.ts
+++ b/src/modules/webext/webext-app/shared/webext-app-helper/webext-app-helper.service.ts
@@ -132,13 +132,13 @@ export default abstract class WebExtAppHelperService extends AppHelperService {
 
   abstract getHelpPages(): string[];
 
-  getNextScheduledSyncUpdateCheck(): ng.IPromise<string> {
+  getNextScheduledSyncUpdateCheck(): ng.IPromise<Date> {
     return browser.alarms.get(Globals.Alarm.Name).then((alarm) => {
       if (!alarm) {
-        return '';
+        return new Date('');
       }
 
-      return (this.$filter('date') as ng.IFilterDate)(new Date(alarm.scheduledTime), 'shortTime');
+      return new Date(alarm.scheduledTime);
     });
   }
 


### PR DESCRIPTION
At current master branch, display of "next sync" date is broken:

![image](https://user-images.githubusercontent.com/20991618/117025739-c084e300-ad2d-11eb-9de9-cf29919c95da.png)

because `getNextScheduledSyncUpdateCheck()` returns a string like `1:23 PM`, which is then parsed to an invalid `Date` object.

The PR fixes this by making `getNextScheduledSyncUpdateCheck()` return a `Date` object.