### PR TITLE
Fix metadata collector for WebExtension

### DIFF
--- a/src/modules/webext/shared/webext-platform/webext-platform.service.ts
+++ b/src/modules/webext/shared/webext-platform/webext-platform.service.ts
@@ -176,9 +176,14 @@ export default abstract class WebExtPlatformService implements PlatformService {
 
       return browser.tabs
         .executeScript(activeTab.id, { file: this.contentScriptUrl })
+        .then(() => {
+          return browser.tabs.executeScript(activeTab.id, {
+            code: 'WebpageMetadataCollecter.CollectMetadata();'
+          });
+        })
         .then((response) => {
-          if (response?.length && response?.[0].default) {
-            metadata = response[0].default;
+          if (response?.length && response?.[0]) {
+            metadata = response[0];
           }
 
           // If no metadata returned, use the info from the active tab

--- a/src/modules/webext/webpage-metadata-collecter/webpage-metadata-collecter.ts
+++ b/src/modules/webext/webpage-metadata-collecter/webpage-metadata-collecter.ts
@@ -98,4 +98,4 @@ class WebpageMetadataCollecter {
     return this.getDecodedTextValue(document.title);
   }
 }
-export default WebpageMetadataCollecter.CollectMetadata();
+export default WebpageMetadataCollecter;

--- a/webpack/chromium.config.js
+++ b/webpack/chromium.config.js
@@ -3,6 +3,7 @@ const WebExtConfig = require('./webext.config');
 
 module.exports = Object.assign(WebExtConfig, {
   entry: {
+    ...WebExtConfig.entry,
     app: Path.resolve(__dirname, '../src/modules/webext/chromium/chromium-app/chromium-app.module.ts'),
     background: Path.resolve(
       __dirname,

--- a/webpack/firefox.config.js
+++ b/webpack/firefox.config.js
@@ -3,6 +3,7 @@ const WebExtConfig = require('./webext.config');
 
 module.exports = Object.assign(WebExtConfig, {
   entry: {
+    ...WebExtConfig.entry,
     app: Path.resolve(__dirname, '../src/modules/webext/firefox/firefox-app/firefox-app.module.ts'),
     background: Path.resolve(__dirname, '../src/modules/webext/firefox/firefox-background/firefox-background.module.ts')
   },

--- a/webpack/webext.config.js
+++ b/webpack/webext.config.js
@@ -29,10 +29,17 @@ const convertI18nForWebExt = (i18n) => {
 
 module.exports = Object.assign(BaseConfig, {
   entry: {
-    webpagemetadatacollecter: Path.resolve(
-      __dirname,
-      '../src/modules/webext/webpage-metadata-collecter/webpage-metadata-collecter.ts'
-    )
+    "webpage-metadata-collecter": {
+      import: Path.resolve(
+        __dirname,
+        '../src/modules/webext/webpage-metadata-collecter/webpage-metadata-collecter.ts'
+      ),
+      library: {
+        name: 'WebpageMetadataCollecter',
+        type: 'var',
+        export: 'default'
+      }
+    }
   },
   plugins: BaseConfig.plugins.concat([
     new CopyWebpackPlugin({


### PR DESCRIPTION
The PR fixes metadata collector by generating and executing content scripts correctly.

Now `webpage-metadata-collecter.js` only assigns variable `WebpageMetadataCollecter` instead of executing `WebpageMetadataCollecter.CollectMetadata();`. Then script `'WebpageMetadataCollecter.CollectMetadata();'` is injected, and we get page metadata in `response[0]`.